### PR TITLE
Swift 5.10 Concurrency improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DataDog/dd-sdk-ios",
       "state" : {
-        "revision" : "bf6043589c308099097e160dbc4d44c32804fc47",
-        "version" : "1.21.0"
+        "revision" : "6eab2d82441c4997ce05f9ecee7d64cc38517fc1",
+        "version" : "2.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,22 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+// Only for development checks
+//    SwiftSetting.unsafeFlags([
+//        "-Xfrontend", "-strict-concurrency=complete",
+//        "-Xfrontend", "-warn-concurrency",
+//        "-Xfrontend", "-enable-actor-data-race-checks",
+//    ])
+]
+
 let package = Package(
     name: "ForestryLogger",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v11),
+        .tvOS(.v11)
+    ],
     products: [
         .library(name: "ForestryLoggerLibrary", targets: ["ForestryLoggerLibrary"]),
         .library(name: "ForestryFileLogger", targets: ["ForestryFileLogger"]),
@@ -15,7 +29,7 @@ let package = Package(
         .library(name: "ForestryOSLogSupport", targets: ["ForestryOSLogSupport"])
     ],
     dependencies: [
-        .package(url: "https://github.com/DataDog/dd-sdk-ios", .upToNextMajor(from: .init(1, 16, 0))),
+        .package(url: "https://github.com/DataDog/dd-sdk-ios", .upToNextMajor(from: .init(2, 7, 1))),
         .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver", .upToNextMajor(from: .init(1, 9, 6))),
         .package(url: "https://github.com/LogRocket/logrocket-ios-swift-package", .upToNextMajor(from: .init(1, 12, 0))),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: .init(8, 3, 0))),
@@ -28,7 +42,8 @@ let package = Package(
                 dependencies: [
                     .product(name: "SwiftyBeaver", package: "SwiftyBeaver"),
                     .target(name: "ForestryLoggerLibrary")
-                ]),
+                ],
+               swiftSettings: swiftSettings),
         .target(name: "ForestryLogRocketSupport",
                 dependencies: [
                     .product(name: "LogRocket", package: "logrocket-ios-swift-package", condition: .when(platforms: [.iOS, .macCatalyst])),
@@ -38,16 +53,22 @@ let package = Package(
                 dependencies: [
                     .product(name: "Sentry", package: "sentry-cocoa"),
                     .target(name: "ForestryLoggerLibrary")
-                ]),
+                ],
+                swiftSettings: swiftSettings),
         .target(name: "ForestryOSLogSupport",
                 dependencies: [
                     .target(name: "ForestryLoggerLibrary")
-                ]),
+                ],
+                swiftSettings: swiftSettings),
         .target(name: "ForestryDatadogSupport",
                 dependencies: [
-                    .product(name: "Datadog", package: "dd-sdk-ios", condition: .when(platforms: [.iOS, .macCatalyst])),
+                    .product(name: "DatadogCore", package: "dd-sdk-ios", condition: .when(platforms: [.iOS, .macCatalyst])),
+                    .product(name: "DatadogLogs", package: "dd-sdk-ios", condition: .when(platforms: [.iOS, .macCatalyst])),
                     .target(name: "ForestryLoggerLibrary")
-                ]),
-        .testTarget(name: "ForestryLoggerLibraryTests", dependencies: ["ForestryLoggerLibrary"])
+                ],
+                swiftSettings: swiftSettings),
+        .testTarget(name: "ForestryLoggerLibraryTests", 
+                    dependencies: ["ForestryLoggerLibrary"],
+                    swiftSettings: swiftSettings)
     ]
 )

--- a/Sources/ForestryDatadogSupport/LogInfo.swift
+++ b/Sources/ForestryDatadogSupport/LogInfo.swift
@@ -5,8 +5,9 @@
 import Foundation
 import ForestryLoggerLibrary
 
-#if canImport(Datadog)
-import Datadog
+#if canImport(DatadogCore)
+import DatadogCore
+import DatadogInternal
 
 typealias LogInfo = ForestryLoggerLibrary.LogInfo
 

--- a/Sources/ForestryDatadogSupport/LogLevel.swift
+++ b/Sources/ForestryDatadogSupport/LogLevel.swift
@@ -3,8 +3,9 @@
 //
 
 import Foundation
-#if canImport(Datadog)
-import Datadog
+#if canImport(DatadogCore)
+import DatadogCore
+import DatadogLogs
 
 // Extension cannot be made on LogLevel, as there is no way to reference Datadog.LogLevel
 extension LogInfo {

--- a/Sources/ForestryLoggerLibrary/ForestryLogger.swift
+++ b/Sources/ForestryLoggerLibrary/ForestryLogger.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A logger that stores its services in a an actor from which all logging is executed asynchronously.
 /// If no service is provided (e.g. for production), the logging library should be free to use without any performance detriments (with only one if check)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-public struct ForestryLogger {
+public struct ForestryLogger: Sendable {
     private let loggerActor: LoggerActor?
     
     /// Can be called with empty array. In such situation, the logger will not perform any activity

--- a/Sources/ForestryLoggerLibrary/LogLevel.swift
+++ b/Sources/ForestryLoggerLibrary/LogLevel.swift
@@ -5,7 +5,7 @@
 
 /// A level of log that determines to which services should the message be logged to
 /// LogLevel also includes the icon that is used within a formatted message
-public enum LogLevel: Int, Comparable {
+public enum LogLevel: Int, Comparable, Sendable {
     case verbose
     case debug
     case info

--- a/Sources/ForestryLoggerLibrary/UserInfo.swift
+++ b/Sources/ForestryLoggerLibrary/UserInfo.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// Keys to set tags or parameters in services (or to be used during logging in these services)
 /// Easily extendable by using a custom key.
-public enum LogUserInfoKey: Hashable {
+public enum LogUserInfoKey: Hashable, Sendable {
     case username
     case email
     case deviceID
@@ -50,7 +50,7 @@ extension LogUserInfoKey {
     /// The KeyType follows the naming from Datadog.
     /// Its use is logger per logger different, for example, for Sentry, both tags and parameters are set as tag()
     /// The type is not printed out in consoleLogger.
-    public enum KeyType: Hashable {
+    public enum KeyType: Hashable, Sendable {
         case tag
         case parameter
     }


### PR DESCRIPTION
This MR improves Forestry's compliance to Swift's Modern Concurrency features. Tested on Swift 5.10's version in Xcode 15.3.0-beta3.