### PR TITLE
Add SentryLogsLogger forwarding to Sentry Structured Logs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,10 @@ let swiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "ForestryLogger",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v15),
         .macOS(.v11),
-        .tvOS(.v11),
-        .watchOS(.v7)
+        .tvOS(.v15),
+        .watchOS(.v8)
     ],
     products: [
         .library(name: "ForestryLoggerLibrary", targets: ["ForestryLoggerLibrary"]),
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/DataDog/dd-sdk-ios", .upToNextMajor(from: .init(2, 7, 1))),
         .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver", .upToNextMajor(from: .init(1, 9, 6))),
         .package(url: "https://github.com/LogRocket/logrocket-ios-swift-package", .upToNextMajor(from: .init(1, 12, 0))),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: .init(8, 3, 0))),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: .init(9, 0, 0))),
         .package(url: "https://github.com/apple/swift-docc-plugin", branch: "main")
     ],
     targets: [
@@ -68,8 +68,11 @@ let package = Package(
                     .target(name: "ForestryLoggerLibrary")
                 ],
                 swiftSettings: swiftSettings),
-        .testTarget(name: "ForestryLoggerLibraryTests", 
+        .testTarget(name: "ForestryLoggerLibraryTests",
                     dependencies: ["ForestryLoggerLibrary"],
+                    swiftSettings: swiftSettings),
+        .testTarget(name: "ForestrySentrySupportTests",
+                    dependencies: ["ForestrySentrySupport", "ForestryLoggerLibrary"],
                     swiftSettings: swiftSettings)
     ]
 )

--- a/Sources/ForestrySentrySupport/SentryLogger.swift
+++ b/Sources/ForestrySentrySupport/SentryLogger.swift
@@ -29,6 +29,14 @@ public struct SentryLogger: LoggerService {
             scope.setTags(dictionary.stringKeyedDictionary)
         }
     }
+
+    public func removeUserInfo(_ keys: [LogUserInfoKey]) {
+        SentrySDK.configureScope { scope in
+            for key in keys {
+                scope.removeTag(key: key.rawValue)
+            }
+        }
+    }
 }
 
 private extension LogLevel {

--- a/Sources/ForestrySentrySupport/SentryLogsLogger.swift
+++ b/Sources/ForestrySentrySupport/SentryLogsLogger.swift
@@ -1,0 +1,127 @@
+//
+//  Copyright 2026 © Cleevio s.r.o. All rights reserved.
+//
+
+import Foundation
+import ForestryLoggerLibrary
+import Sentry
+
+/// A logger that forwards all logs to Sentry Structured Logs (`SentrySDK.logger`).
+///
+/// This service does NOT start the SentrySDK. The SDK must be started with
+/// `options.enableLogs = true` before any log is emitted — either by composing
+/// a `SentryLogger` in the same `ForestryLogger`, or by using
+/// `init(startingSDKWith:)`. If the SDK is not started, sentry-cocoa silently
+/// drops the logs (no crash).
+public final class SentryLogsLogger: LoggerService {
+    public var minimalLogLevel: ForestryLoggerLibrary.LogLevel = .verbose
+
+    /// UserInfo keys of type `.parameter`, attached to every log as attributes.
+    /// Only mutated from ForestryLogger's internal actor, which serializes all calls.
+    private var parameterUserInfo: [String: String] = [:]
+
+    /// Testability seam: receives (level, body, attributes).
+    internal var dispatch: (SentryLog.Level, String, [String: Any]) -> Void
+
+    /// Use when SentrySDK.start is owned elsewhere (e.g. by a composed `SentryLogger`).
+    public init() {
+        self.dispatch = Self.sentrySDKDispatch
+    }
+
+    /// Starts the SDK (forcing `enableLogs = true`) unless it is already running.
+    /// Use when `SentryLogsLogger` is the only Sentry service in the composition.
+    public convenience init(startingSDKWith options: @autoclosure () -> Sentry.Options) {
+        self.init()
+        guard !SentrySDK.isEnabled else { return }
+        let options = options()
+        options.enableLogs = true
+        SentrySDK.start(options: options)
+    }
+
+    public func log(info: LogInfo) {
+        let attributes = Self.makeAttributes(info: info, userInfo: parameterUserInfo)
+        dispatch(info.level.asSentryLogLevel, String(describing: info.message), attributes)
+    }
+
+    public func configureUserInfo(_ dictionary: [LogUserInfoKey: String]) {
+        var tags: [String: String] = [:]
+        for (key, value) in dictionary {
+            switch key.type {
+            case .parameter:
+                parameterUserInfo[key.rawValue] = value
+            case .tag:
+                tags[key.rawValue] = value
+            }
+        }
+        if !tags.isEmpty {
+            SentrySDK.configureScope { scope in
+                scope.setTags(tags)
+            }
+        }
+    }
+
+    public func removeUserInfo(_ keys: [LogUserInfoKey]) {
+        for key in keys {
+            switch key.type {
+            case .parameter:
+                parameterUserInfo[key.rawValue] = nil
+            case .tag:
+                SentrySDK.configureScope { scope in
+                    scope.removeTag(key: key.rawValue)
+                }
+            }
+        }
+    }
+
+    /// Builds per-log attributes. UserInfo never overrides the `code.*` keys.
+    internal static func makeAttributes(info: LogInfo, userInfo: [String: String]) -> [String: Any] {
+        var attributes: [String: Any] = userInfo
+        attributes["code.file"] = info.file
+        attributes["code.function"] = info.function
+        attributes["code.line"] = info.line
+        return attributes
+    }
+
+    private static func sentrySDKDispatch(level: SentryLog.Level, body: String, attributes: [String: Any]) {
+        let logger = SentrySDK.logger
+        switch level {
+        case .trace:
+            logger.trace(body, attributes: attributes)
+        case .debug:
+            logger.debug(body, attributes: attributes)
+        case .info:
+            logger.info(body, attributes: attributes)
+        case .warn:
+            logger.warn(body, attributes: attributes)
+        case .error:
+            logger.error(body, attributes: attributes)
+        case .fatal:
+            logger.fatal(body, attributes: attributes)
+        @unknown default:
+            logger.info(body, attributes: attributes)
+        }
+    }
+}
+
+internal extension ForestryLoggerLibrary.LogLevel {
+    var asSentryLogLevel: SentryLog.Level {
+        switch self {
+        case .verbose:
+            return .trace
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .warning:
+            return .warn
+        case .error:
+            return .error
+        }
+    }
+}
+
+public extension LoggerService where Self == SentryLogsLogger {
+    /// A logger that forwards all logs to Sentry Structured Logs.
+    /// SentrySDK must already be started with `enableLogs = true`.
+    static var sentryLogs: SentryLogsLogger { .init() }
+}

--- a/Sources/ForestrySentrySupport/SentryUserIdentity.swift
+++ b/Sources/ForestrySentrySupport/SentryUserIdentity.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright 2026 © Cleevio s.r.o. All rights reserved.
+//
+
+import Foundation
+import Sentry
+
+/// Sets the Sentry scope user so that logs, events and replays are filterable per user,
+/// without the host app having to link Sentry directly.
+public enum SentryUserIdentity {
+    /// Sets the current Sentry user. Passing a nil `id` clears the user (e.g. on logout).
+    public static func set(id: String?, email: String? = nil, username: String? = nil) {
+        guard let id else {
+            SentrySDK.setUser(nil)
+            return
+        }
+        let user = User(userId: id)
+        user.email = email
+        user.username = username
+        SentrySDK.setUser(user)
+    }
+}

--- a/Tests/ForestrySentrySupportTests/SentryLogsLoggerTests.swift
+++ b/Tests/ForestrySentrySupportTests/SentryLogsLoggerTests.swift
@@ -1,0 +1,104 @@
+//
+//  Copyright 2026 © Cleevio s.r.o. All rights reserved.
+//
+
+import Foundation
+@testable import ForestryLoggerLibrary
+@testable import ForestrySentrySupport
+import Sentry
+import XCTest
+
+final class SentryLogsLoggerTests: XCTestCase {
+    private var logger: SentryLogsLogger!
+    private var dispatched: [(level: SentryLog.Level, body: String, attributes: [String: Any])] = []
+
+    override func setUp() {
+        super.setUp()
+
+        logger = SentryLogsLogger()
+        dispatched = []
+        logger.dispatch = { [weak self] level, body, attributes in
+            self?.dispatched.append((level, body, attributes))
+        }
+    }
+
+    private func makeLogInfo(
+        level: LogLevel = .info,
+        message: Any = "Message",
+        file: String = "/Some/Path/AppDelegate.swift",
+        function: String = "application(_:didFinishLaunchingWithOptions:)",
+        line: Int = 42
+    ) -> LogInfo {
+        LogInfo(level: level, line: line, function: function, file: file, message: message, icon: "ℹ️")
+    }
+
+    // MARK: - Level mapping
+
+    func testLevelMapping() {
+        XCTAssertEqual(LogLevel.verbose.asSentryLogLevel, .trace)
+        XCTAssertEqual(LogLevel.debug.asSentryLogLevel, .debug)
+        XCTAssertEqual(LogLevel.info.asSentryLogLevel, .info)
+        XCTAssertEqual(LogLevel.warning.asSentryLogLevel, .warn)
+        XCTAssertEqual(LogLevel.error.asSentryLogLevel, .error)
+    }
+
+    func testLogDispatchesMappedLevel() {
+        logger.log(info: makeLogInfo(level: .warning))
+
+        XCTAssertEqual(dispatched.count, 1)
+        XCTAssertEqual(dispatched.first?.level, .warn)
+    }
+
+    // MARK: - Body
+
+    func testBodyIsVerbatimMessageWithoutFormattingPrefix() {
+        logger.log(info: makeLogInfo(message: "Raw message"))
+
+        XCTAssertEqual(dispatched.first?.body, "Raw message")
+    }
+
+    // MARK: - Attributes
+
+    func testCodeAttributes() {
+        logger.log(info: makeLogInfo())
+
+        let attributes = dispatched.first?.attributes
+        // LogInfo normalizes the file name (path and .swift extension stripped)
+        XCTAssertEqual(attributes?["code.file"] as? String, "AppDelegate")
+        XCTAssertEqual(attributes?["code.function"] as? String, "application(_:didFinishLaunchingWithOptions:)")
+        XCTAssertEqual(attributes?["code.line"] as? Int, 42)
+    }
+
+    func testParameterUserInfoIsAttachedAsAttributes() {
+        logger.configureUserInfo([.userID: "user-123", .sceneIdentifier: "scene-1"])
+        logger.log(info: makeLogInfo())
+
+        let attributes = dispatched.first?.attributes
+        XCTAssertEqual(attributes?["userID"] as? String, "user-123")
+        XCTAssertEqual(attributes?["sceneIdentifier"] as? String, "scene-1")
+    }
+
+    func testUserInfoCannotOverrideCodeAttributes() {
+        let attributes = SentryLogsLogger.makeAttributes(
+            info: makeLogInfo(),
+            userInfo: ["code.file": "Spoofed", "custom": "value"]
+        )
+
+        XCTAssertEqual(attributes["code.file"] as? String, "AppDelegate")
+        XCTAssertEqual(attributes["custom"] as? String, "value")
+    }
+
+    func testRemoveUserInfoRemovesParameterKeys() {
+        logger.configureUserInfo([.userID: "user-123"])
+        logger.removeUserInfo([.userID])
+        logger.log(info: makeLogInfo())
+
+        XCTAssertNil(dispatched.first?.attributes["userID"])
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultMinimalLogLevelIsVerbose() {
+        XCTAssertEqual(SentryLogsLogger().minimalLogLevel, .verbose)
+    }
+}


### PR DESCRIPTION
- New SentryLogsLogger LoggerService that forwards all levels to SentrySDK.logger with code.file/code.function/code.line attributes and parameter userInfo attached per log; tag userInfo goes to scope.
- Level mapping: verbose->trace, debug->debug, info->info, warning->warn, error->error.
- Does not start the SDK by default (composable next to SentryLogger, which owns SentrySDK.start); init(startingSDKWith:) for standalone use forces options.enableLogs = true.
- New SentryUserIdentity helper wrapping SentrySDK.setUser so host apps do not need to link Sentry directly.
- Implement missing removeUserInfo on SentryLogger.
- Bump sentry-cocoa minimum to 9.0.0 (stable structured logs API).

## Description

[Explain what this PR does, and why it's important.]

## Changes

[List the specific changes made in this PR.]

- [Change 1]
- [Change 2]

## Related Issue(s)

[If there is an existing issue related to this PR, include its number here.]

## Checklist

- [ ] I have tested this code on my local machine and it works as expected.
- [ ] I have added necessary documentation and comments.
- [ ] I have added unit tests and they all pass.
- [ ] I have followed the project's code style guidelines.
- [ ] I have updated the README file (if applicable).